### PR TITLE
Auth: UX changes 

### DIFF
--- a/client/src/pages/auth/forgot-password/[passwordResetToken].tsx
+++ b/client/src/pages/auth/forgot-password/[passwordResetToken].tsx
@@ -8,13 +8,15 @@ import {
   Input,
   Button,
   useToast,
+  InputRightElement,
+  InputGroup,
 } from '@chakra-ui/react'
 import { useRouter } from 'next/router'
 import { useEffect, useState } from 'react'
 import { sendPasswordResetRequest } from '../../../services/axiosService'
 import * as yup from 'yup'
 import { Formik, Form, Field } from 'formik'
-
+import { AiOutlineEyeInvisible, AiOutlineEye } from 'react-icons/ai'
 interface PasswordResetValues {
   password: string
   confirmPassword: string
@@ -29,7 +31,7 @@ export const PasswordResetSchema = yup.object().shape({
       'Must Contain 8 Characters, mix of numbers and alphabets.'
     )
     .min(8, 'Password must be atleast 8 characters long.'),
-  newPassword: yup
+  confirmPassword: yup
     .string()
     .oneOf([yup.ref('password'), null], 'Passwords must match.'),
 })
@@ -40,6 +42,8 @@ export default function PasswordResetForm() {
   const passwordResetToken = router.query.passwordResetToken as string
 
   const [token, setToken] = useState('')
+
+  const [showPassword, setShowPassword] = useState<boolean>(false)
 
   useEffect(() => {
     if (!passwordResetToken) {
@@ -107,12 +111,27 @@ export default function PasswordResetForm() {
                   isInvalid={form.errors.password && form.touched.password}
                 >
                   <FormLabel htmlFor="password">New Password</FormLabel>
-                  <Input
-                    {...field}
-                    id="password"
-                    placeholder="Your password"
-                    type="password"
-                  />
+                  <InputGroup>
+                    <Input
+                      {...field}
+                      id="password"
+                      placeholder="Your password"
+                      type={showPassword ? 'text' : 'password'}
+                    />
+                    <InputRightElement mr="4">
+                      <Button
+                        h="1.75rem"
+                        size="sm"
+                        onClick={() => setShowPassword(!showPassword)}
+                      >
+                        {showPassword ? (
+                          <AiOutlineEyeInvisible />
+                        ) : (
+                          <AiOutlineEye />
+                        )}
+                      </Button>
+                    </InputRightElement>
+                  </InputGroup>
                   <FormErrorMessage>{form.errors.password}</FormErrorMessage>
                 </FormControl>
               )}

--- a/client/src/pages/auth/signup.tsx
+++ b/client/src/pages/auth/signup.tsx
@@ -41,8 +41,13 @@ const SignUpSchema = yup.object().shape({
     .string()
     .required('First Name is required.')
     .min(2, 'First name must be atleast 2 characters long.')
+    .matches(/^[A-Za-z ]*$/, 'Please use only alphabets.')
     .trim(),
-  lastName: yup.string().required('Last name is required.'),
+  lastName: yup
+    .string()
+    .required('Last name is required.')
+    .matches(/^[A-Za-z ]*$/, 'Please use only alphabets.')
+    .trim(),
   email: yup
     .string()
     .email('Email must be a valid email address.')

--- a/client/src/pages/auth/signup.tsx
+++ b/client/src/pages/auth/signup.tsx
@@ -324,15 +324,21 @@ export default function SignUp() {
                           Log in instead
                         </Link>
                       </NextLink>
-
-                      <Button
-                        isLoading={isLoading}
-                        type="submit"
-                        colorscheme={'blue'}
-                        variant={'solid'}
-                      >
-                        Create Account
-                      </Button>
+                      <Field>
+                        {({ form }) => {
+                          return (
+                            <Button
+                              isLoading={isLoading}
+                              type="submit"
+                              colorscheme={'blue'}
+                              variant={'solid'}
+                              disabled={!form.isValid}
+                            >
+                              Create Account
+                            </Button>
+                          )
+                        }}
+                      </Field>
                     </Flex>
                   </Stack>
                 </Stack>


### PR DESCRIPTION
### Fixes
- Fixed an issue where user could put special symbols, numbers as names.
- Fixed an issue where password matching wouldn't work on the reset password form.
- Sign up button stays disabled until the form is validated.
- Added show password button reset password form.

### Screenshots or Video GIFs
![image](https://user-images.githubusercontent.com/45557594/124704250-5f39e580-df11-11eb-84f4-07e139ccb449.png)
![image](https://user-images.githubusercontent.com/45557594/124704331-87294900-df11-11eb-9974-f51c6427726e.png)

### Related Issues
- Issues discussed in standup.

### Author Checklist
- [ ] Vital features and changes captured in unit and/or integration tests
- [ ] Extend the documentation, if necessary
- [ ] Merging to `main` from `fork:branchname`