### PR TITLE
feat : add support for custom email templates

### DIFF
--- a/client/src/pages/auth/forgot-password/[passwordResetToken].tsx
+++ b/client/src/pages/auth/forgot-password/[passwordResetToken].tsx
@@ -151,7 +151,7 @@ export default function PasswordResetForm() {
                   <Input
                     {...field}
                     id="confirmPassword"
-                    placeholder="Your confirmPassword"
+                    placeholder="Re-enter your new password"
                     type="password"
                   />
                   <FormErrorMessage>

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "debug": "^4.3.1",
     "dotenv": "^10.0.0",
     "express": "^4.17.1",
+    "handlebars": "^4.7.7",
     "http": "^0.0.1-security",
     "http-errors": "^1.8.0",
     "jsonwebtoken": "^8.5.1",

--- a/src/templates/hello.hbs
+++ b/src/templates/hello.hbs
@@ -1,0 +1,12 @@
+<html>
+  <head>
+    <title>Message HTML Title</title>
+  </head>
+  <body>
+    <div>
+      <span style="font-weight: bold;">Message: </span>
+      <span>{{message}}</span>
+      <span>{{resetURL}}</span>
+    </div>
+  </body>
+</html>

--- a/src/templates/reset-password.hbs
+++ b/src/templates/reset-password.hbs
@@ -126,7 +126,7 @@
                         >neogcamp@gmail.com</a>
                       </p>
                       <a
-                        href={{resetPasswordLink}}
+                        href={{resetURL}}
                         style='
                           background: #03abc5;
                           text-decoration: none !important;
@@ -145,13 +145,13 @@
                           color: #455056;
                           font-size: 15px;
                           line-height: 24px;
-                          margin: 0;
+                          margin-top: 15px;
                         '
                       >
                         <a
-                          href={{resetPasswordLink}}
+                          href={{resetURL}}
                           style='color: #035f6d'
-                        >{{resetPasswordLink}}</a>
+                        >{{resetURL}}</a>
                       </p>
                     </td>
                   </tr>

--- a/src/templates/reset-password.hbs
+++ b/src/templates/reset-password.hbs
@@ -1,0 +1,244 @@
+<html lang='en-US'>
+  <head>
+    <meta content='text/html; charset=utf-8' http-equiv='Content-Type' />
+    <title>Reset Your Password</title>
+    <meta name='description' content='Reset Your Password' />
+    <style type='text/css'>
+      a:hover { text-decoration: underline !important; }
+    </style>
+  </head>
+
+  <body
+    marginheight='0'
+    topmargin='0'
+    marginwidth='0'
+    style='margin: 0px; background-color: #f2f3f8'
+    leftmargin='0'
+  >
+    <!--100% body table-->
+    <table
+      cellspacing='0'
+      border='0'
+      cellpadding='0'
+      width='100%'
+      bgcolor='#f2f3f8'
+      style="
+        @import url(https://fonts.googleapis.com/css?family=Rubik:300,400,500,700|Open+Sans:300,400,600,700);
+        font-family: 'Open Sans', sans-serif;
+      "
+    >
+      <tr>
+        <td>
+          <table
+            style='background-color: #f2f3f8; max-width: 670px; margin: 0 auto'
+            width='100%'
+            border='0'
+            align='center'
+            cellpadding='0'
+            cellspacing='0'
+          >
+            <tr>
+              <td style='height: 80px'>&nbsp;</td>
+            </tr>
+            <tr>
+              <td style='text-align: center'>
+                <a href='https://neog.camp' title='logo' target='_blank'>
+                  <img
+                    width='60'
+                    src='https://cdn.discordapp.com/attachments/781013061476941835/862344087403233330/neoG_Camp.jpeg'
+                    title='logo'
+                    alt='logo'
+                  />
+                </a>
+              </td>
+            </tr>
+            <tr>
+              <td style='height: 20px'>&nbsp;</td>
+            </tr>
+            <tr>
+              <td>
+                <table
+                  width='95%'
+                  border='0'
+                  align='center'
+                  cellpadding='0'
+                  cellspacing='0'
+                  style='
+                    max-width: 670px;
+                    background: #fff;
+                    border-radius: 3px;
+                    text-align: center;
+                    -webkit-box-shadow: 0 6px 18px 0 rgba(0, 0, 0, 0.06);
+                    -moz-box-shadow: 0 6px 18px 0 rgba(0, 0, 0, 0.06);
+                    box-shadow: 0 6px 18px 0 rgba(0, 0, 0, 0.06);
+                  '
+                >
+                  <tr>
+                    <td style='height: 40px'>&nbsp;</td>
+                  </tr>
+                  <tr>
+                    <td style='padding: 0 35px'>
+                      <h1
+                        style="
+                          color: #1e1e2d;
+                          font-weight: 500;
+                          margin: 0;
+                          font-size: 32px;
+                          font-family: 'Rubik', sans-serif;
+                        "
+                      >
+                        You have requested to reset your password
+                      </h1>
+                      <span
+                        style='
+                          display: inline-block;
+                          vertical-align: middle;
+                          margin: 29px 0 26px;
+                          border-bottom: 1px solid #cecece;
+                          width: 100px;
+                        '
+                      ></span>
+                      <p
+                        style='
+                          color: #455056;
+                          font-size: 15px;
+                          line-height: 24px;
+                          margin: 0;
+                        '
+                      >
+                        We cannot simply send you your old password. A unique
+                        link to reset your password has been generated for you.
+                        To reset your password, click the following link and
+                        follow the instructions.
+                      </p>
+                      <p
+                        style='
+                          color: #455056;
+                          font-size: 15px;
+                          line-height: 24px;
+                          margin: 0;
+                        '
+                      >
+                        If you have any query, feel free to reach out to us on
+                        <a
+                          href='mailto: neogcamp@gmail.com'
+                          style='color: #035f6d'
+                        >neogcamp@gmail.com</a>
+                      </p>
+                      <a
+                        href={{resetPasswordLink}}
+                        style='
+                          background: #03abc5;
+                          text-decoration: none !important;
+                          font-weight: 500;
+                          margin-top: 35px;
+                          color: #fff;
+                          text-transform: uppercase;
+                          font-size: 14px;
+                          padding: 10px 24px;
+                          display: inline-block;
+                          border-radius: 50px;
+                        '
+                      >Reset Password</a>
+                      <p
+                        style='
+                          color: #455056;
+                          font-size: 15px;
+                          line-height: 24px;
+                          margin: 0;
+                        '
+                      >
+                        <a
+                          href={{resetPasswordLink}}
+                          style='color: #035f6d'
+                        >{{resetPasswordLink}}</a>
+                      </p>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td style='height: 40px'>&nbsp;</td>
+                  </tr>
+                </table>
+              </td>
+            </tr>
+
+            <tr>
+              <td style='height: 20px'>&nbsp;</td>
+            </tr>
+            <tr>
+              <td style='text-align: center'>
+                <p
+                  style='
+                    font-size: 14px;
+                    color: rgba(69, 80, 86, 0.7411764705882353);
+                    line-height: 18px;
+                    margin: 0 0 0;
+                  '
+                >
+                  &copy;
+                  <strong><a
+                      href='https://neog.camp'
+                      style='color: rgba(69, 80, 86, 0.7411764705882353)'
+                    >https://neog.camp</a></strong>
+                </p>
+                <p style='color: rgba(85, 97, 104, 0.741)'>
+                  <a
+                    href='https://www.instagram.com/neogcamp'
+                    style='
+                      color: rgba(85, 97, 104, 0.741);
+                      text-decoration: none;
+                    '
+                  >Instagram</a>
+                  |
+                  <a
+                    href='https://twitter.com/neogcamp'
+                    style='
+                      color: rgba(85, 97, 104, 0.741);
+                      text-decoration: none;
+                    '
+                  >Twitter</a>
+                  |
+                  <a
+                    href='https://www.youtube.com/watch?v=Ezk2AwqgS9Q&list=PLzvhQUIpvvuj5KPnyPyWsvgyzNkX_ACPA'
+                    style='
+                      color: rgba(85, 97, 104, 0.741);
+                      text-decoration: none;
+                    '
+                  >Youtube</a>
+                  |
+                  <a
+                    href='https://www.linkedin.com/company/neog-camp/'
+                    style='
+                      color: rgba(85, 97, 104, 0.741);
+                      text-decoration: none;
+                    '
+                  >Linkedin</a>
+                  |
+                  <a
+                    href='https://bit.ly/tanaydiscord'
+                    style='
+                      color: rgba(85, 97, 104, 0.741);
+                      text-decoration: none;
+                    '
+                  >Discord</a>
+                  |
+                  <a
+                    href='https://t.me/tanaypratap'
+                    style='
+                      color: rgba(85, 97, 104, 0.741);
+                      text-decoration: none;
+                    '
+                  >Telegram</a>
+                </p>
+              </td>
+            </tr>
+            <tr>
+              <td style='height: 80px'>&nbsp;</td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>
+    <!--/100% body table-->
+  </body>
+</html>

--- a/src/templates/verify-Email.hbs
+++ b/src/templates/verify-Email.hbs
@@ -1,0 +1,244 @@
+<html lang='en-US'>
+  <head>
+    <meta content='text/html; charset=utf-8' http-equiv='Content-Type' />
+    <title>Verify Your Email</title>
+    <meta name='description' content='Verify Your Email' />
+    <style type='text/css'>
+      a:hover { text-decoration: underline !important; }
+    </style>
+  </head>
+
+  <body
+    marginheight='0'
+    topmargin='0'
+    marginwidth='0'
+    style='margin: 0px; background-color: #f2f3f8'
+    leftmargin='0'
+  >
+    <!--100% body table-->
+    <table
+      cellspacing='0'
+      border='0'
+      cellpadding='0'
+      width='100%'
+      bgcolor='#f2f3f8'
+      style="
+        @import url(https://fonts.googleapis.com/css?family=Rubik:300,400,500,700|Open+Sans:300,400,600,700);
+        font-family: 'Open Sans', sans-serif;
+      "
+    >
+      <tr>
+        <td>
+          <table
+            style='background-color: #f2f3f8; max-width: 670px; margin: 0 auto'
+            width='100%'
+            border='0'
+            align='center'
+            cellpadding='0'
+            cellspacing='0'
+          >
+            <tr>
+              <td style='height: 80px'>&nbsp;</td>
+            </tr>
+            <tr>
+              <td style='text-align: center'>
+                <a href='https://neog.camp' title='logo' target='_blank'>
+                  <img
+                    width='60'
+                    src='https://cdn.discordapp.com/attachments/781013061476941835/862344087403233330/neoG_Camp.jpeg'
+                    title='logo'
+                    alt='logo'
+                  />
+                </a>
+              </td>
+            </tr>
+            <tr>
+              <td style='height: 20px'>&nbsp;</td>
+            </tr>
+            <tr>
+              <td>
+                <table
+                  width='95%'
+                  border='0'
+                  align='center'
+                  cellpadding='0'
+                  cellspacing='0'
+                  style='
+                    max-width: 670px;
+                    background: #fff;
+                    border-radius: 3px;
+                    text-align: center;
+                    -webkit-box-shadow: 0 6px 18px 0 rgba(0, 0, 0, 0.06);
+                    -moz-box-shadow: 0 6px 18px 0 rgba(0, 0, 0, 0.06);
+                    box-shadow: 0 6px 18px 0 rgba(0, 0, 0, 0.06);
+                  '
+                >
+                  <tr>
+                    <td style='height: 40px'>&nbsp;</td>
+                  </tr>
+                  <tr>
+                    <td style='padding: 0 35px'>
+                      <h1
+                        style="
+                          color: #1e1e2d;
+                          font-weight: 500;
+                          margin: 0;
+                          font-size: 32px;
+                          font-family: 'Rubik', sans-serif;
+                        "
+                      >
+                        Please verify your email
+                      </h1>
+                      <span
+                        style='
+                          display: inline-block;
+                          vertical-align: middle;
+                          margin: 29px 0 26px;
+                          border-bottom: 1px solid #cecece;
+                          width: 100px;
+                        '
+                      ></span>
+                      <p
+                        style='
+                          color: #455056;
+                          font-size: 15px;
+                          line-height: 24px;
+                          margin: 0;
+                        '
+                      >
+                        Thanks for signing up! We just need you to verify your
+                        email address to complete setting up your account. To
+                        verify your email, click on the following link and
+                        you'll be redirected to a new page.
+                      </p>
+                      <p
+                        style='
+                          color: #455056;
+                          font-size: 15px;
+                          line-height: 24px;
+                          margin: 0;
+                        '
+                      >
+                        If you have any query, feel free to reach out to us on
+                        <a
+                          href='mailto: neogcamp@gmail.com'
+                          style='color: #035f6d'
+                        >neogcamp@gmail.com</a>
+                      </p>
+                      <a
+                        href={{verifyEmailLink}}
+                        style='
+                          background: #03abc5;
+                          text-decoration: none !important;
+                          font-weight: 500;
+                          margin-top: 35px;
+                          color: #fff;
+                          text-transform: uppercase;
+                          font-size: 14px;
+                          padding: 10px 24px;
+                          display: inline-block;
+                          border-radius: 50px;
+                        '
+                      >Verify Email</a>
+                      <p
+                        style='
+                          color: #455056;
+                          font-size: 15px;
+                          line-height: 24px;
+                          margin: 0;
+                        '
+                      >
+                        <a
+                          href={{resetLink}}
+                          style='color: #035f6d'
+                        >{{resetLink}}</a>
+                      </p>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td style='height: 40px'>&nbsp;</td>
+                  </tr>
+                </table>
+              </td>
+            </tr>
+
+            <tr>
+              <td style='height: 20px'>&nbsp;</td>
+            </tr>
+            <tr>
+              <td style='text-align: center'>
+                <p
+                  style='
+                    font-size: 14px;
+                    color: rgba(69, 80, 86, 0.7411764705882353);
+                    line-height: 18px;
+                    margin: 0 0 0;
+                  '
+                >
+                  &copy;
+                  <strong><a
+                      href='https://neog.camp'
+                      style='color: rgba(69, 80, 86, 0.7411764705882353)'
+                    >https://neog.camp</a></strong>
+                </p>
+                <p style='color: rgba(85, 97, 104, 0.741)'>
+                  <a
+                    href='https://www.instagram.com/neogcamp'
+                    style='
+                      color: rgba(85, 97, 104, 0.741);
+                      text-decoration: none;
+                    '
+                  >Instagram</a>
+                  |
+                  <a
+                    href='https://twitter.com/neogcamp'
+                    style='
+                      color: rgba(85, 97, 104, 0.741);
+                      text-decoration: none;
+                    '
+                  >Twitter</a>
+                  |
+                  <a
+                    href='https://www.youtube.com/watch?v=Ezk2AwqgS9Q&list=PLzvhQUIpvvuj5KPnyPyWsvgyzNkX_ACPA'
+                    style='
+                      color: rgba(85, 97, 104, 0.741);
+                      text-decoration: none;
+                    '
+                  >Youtube</a>
+                  |
+                  <a
+                    href='https://www.linkedin.com/company/neog-camp/'
+                    style='
+                      color: rgba(85, 97, 104, 0.741);
+                      text-decoration: none;
+                    '
+                  >Linkedin</a>
+                  |
+                  <a
+                    href='https://bit.ly/tanaydiscord'
+                    style='
+                      color: rgba(85, 97, 104, 0.741);
+                      text-decoration: none;
+                    '
+                  >Discord</a>
+                  |
+                  <a
+                    href='https://t.me/tanaypratap'
+                    style='
+                      color: rgba(85, 97, 104, 0.741);
+                      text-decoration: none;
+                    '
+                  >Telegram</a>
+                </p>
+              </td>
+            </tr>
+            <tr>
+              <td style='height: 80px'>&nbsp;</td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>
+    <!--/100% body table-->
+  </body>
+</html>

--- a/src/templates/verify-Email.hbs
+++ b/src/templates/verify-Email.hbs
@@ -126,7 +126,7 @@
                         >neogcamp@gmail.com</a>
                       </p>
                       <a
-                        href={{verifyEmailLink}}
+                        href={{verificationLink}}
                         style='
                           background: #03abc5;
                           text-decoration: none !important;
@@ -145,13 +145,13 @@
                           color: #455056;
                           font-size: 15px;
                           line-height: 24px;
-                          margin: 0;
+                          margin-top: 15px;
                         '
                       >
                         <a
-                          href={{resetLink}}
+                          href={{verificationLink}}
                           style='color: #035f6d'
-                        >{{resetLink}}</a>
+                        >{{verificationLink}}</a>
                       </p>
                     </td>
                   </tr>

--- a/src/utils/mailer.ts
+++ b/src/utils/mailer.ts
@@ -18,7 +18,7 @@ interface IEmail {
 
 export class Email implements IEmail {
   // @future _> this will change
-  from = '<neoG Camp> no-reply@neogcamp.in'
+  from = '<neoG Camp> no-reply@neog.camp'
   to = ''
   firstName = ''
 

--- a/src/utils/mailer.ts
+++ b/src/utils/mailer.ts
@@ -1,0 +1,102 @@
+import nodemailer, { Transport, Transporter } from 'nodemailer'
+import handlebars from 'handlebars'
+import SMTPTransport from 'nodemailer/lib/smtp-transport'
+import fs from 'fs'
+import path from 'path'
+import log from './logger'
+
+interface User {
+  readonly email: string
+  readonly firstName: string
+}
+
+interface IEmail {
+  readonly from: string
+  readonly to: string
+  readonly firstName: string
+}
+
+export class Email implements IEmail {
+  // @future _> this will change
+  from = '<neoG Camp> no-reply@neogcamp.in'
+  to = ''
+  firstName = ''
+
+  constructor(user: User) {
+    this.to = user.email
+    this.firstName = user.firstName
+  }
+
+  newTransport() {
+    console.log(process.env.EMAIL_PORT)
+    return nodemailer.createTransport({
+      host: process.env.EMAIL_HOST,
+      port: process.env.EMAIL_PORT,
+      auth: {
+        user: process.env.EMAIL_USERNAME,
+        pass: process.env.EMAIL_PASSWORD,
+      },
+    } as SMTPTransport.Options)
+  }
+
+  async send({
+    template,
+    subject,
+    variables,
+  }: {
+    //   template is templateID so its probably gonna be a file name
+    template: string
+    subject: string
+    //send any variables like links and tokens etc
+    variables: Record<string, unknown>
+  }) {
+    //html
+    try {
+      const emailTemplate = fs.readFileSync(
+        path.join(__dirname, '..', 'templates', `${template}.hbs`),
+        'utf8'
+      )
+
+      const html = handlebars.compile(emailTemplate)
+
+      const htmlToSend = html({
+        ...variables,
+      })
+      // mailOPtions
+      const mailOptions = {
+        to: this.to,
+        from: this.from,
+        subject,
+        html: htmlToSend,
+      }
+
+      await this.newTransport().sendMail(mailOptions, (error, response) => {
+        if (error) {
+          console.log('Error occured while sending email', error)
+        } else {
+          console.log('Response after sending email', response)
+        }
+      })
+    } catch (error) {
+      if (error.code === 'ENOENT') {
+        log.error(
+          `The template with the name ${template} does not exitst in templtes directory. Please double check the file name or create the file`
+        )
+      }
+      log.error(`This error occured during sending emails`, error)
+    }
+  }
+}
+//testing purpose --delete me ---
+export async function sendEmail() {
+  await new Email({
+    email: 'omkarak@gmail.com',
+    firstName: 'Omkar',
+  }).send({
+    subject: 'Password Reset Link',
+    template: 'hello',
+    variables: {
+      resetURL: 'http://resetPassword.com',
+    },
+  })
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1576,6 +1576,18 @@ graceful-fs@^4.1.2:
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.6.tgz#ff040b2b0853b23c3d31027523706f1885d76bee"
   integrity sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==
 
+handlebars@^4.7.7:
+  version "4.7.7"
+  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.7.tgz#9ce33416aad02dbd6c8fafa8240d5d98004945a1"
+  integrity sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==
+  dependencies:
+    minimist "^1.2.5"
+    neo-async "^2.6.0"
+    source-map "^0.6.1"
+    wordwrap "^1.0.0"
+  optionalDependencies:
+    uglify-js "^3.1.4"
+
 has-bigints@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/has-bigints/-/has-bigints-1.0.1.tgz#64fe6acb020673e3b78db035a5af69aa9d07b113"
@@ -2381,6 +2393,11 @@ negotiator@0.6.2:
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.2.tgz#feacf7ccf525a77ae9634436a64883ffeca346fb"
   integrity sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==
 
+neo-async@^2.6.0:
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
+  integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
+
 node-addon-api@^3.1.0:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-3.2.1.tgz#81325e0a2117789c0128dab65e7e38f07ceba161"
@@ -3046,7 +3063,7 @@ source-map-support@^0.5.12, source-map-support@^0.5.17:
     buffer-from "^1.0.0"
     source-map "^0.6.0"
 
-source-map@^0.6.0:
+source-map@^0.6.0, source-map@^0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
@@ -3420,6 +3437,11 @@ typescript@^4.3.4:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.4.tgz#3f85b986945bcf31071decdd96cf8bfa65f9dcbc"
   integrity sha512-uauPG7XZn9F/mo+7MrsRjyvbxFpzemRjKEZXS4AK83oP2KKOJPvb+9cO/gmnv8arWZvhnjVOXz7B49m1l0e9Ew==
 
+uglify-js@^3.1.4:
+  version "3.13.10"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.13.10.tgz#a6bd0d28d38f592c3adb6b180ea6e07e1e540a8d"
+  integrity sha512-57H3ACYFXeo1IaZ1w02sfA71wI60MGco/IQFjOqK+WtKoprh7Go2/yvd2HPtoJILO2Or84ncLccI4xoHMTSbGg==
+
 unbox-primitive@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/unbox-primitive/-/unbox-primitive-1.0.1.tgz#085e215625ec3162574dc8859abee78a59b14471"
@@ -3522,6 +3544,11 @@ word-wrap@^1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.3.tgz#610636f6b1f703891bd34771ccb17fb93b47079c"
   integrity sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==
+
+wordwrap@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
+  integrity sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=
 
 wrap-ansi@^6.2.0:
   version "6.2.0"


### PR DESCRIPTION
This adds support for sending custom email templates written in HBS (Handlebars).
To use this function please refer this doc. -> notion
 https://oksnotes.notion.site/How-to-use-sendEmail-function-91ca52ca34c74e98b7c9875faba05a1d

We will eventually migrate from old sendEmail function which was located in config/emailOptions in favor of this one.

<!--- Provide a formatted commit message describing this PR in the Title above -->

# Partially Closes #64 
- Adds support for creating custom and dynamic email templates

### Changes
- No major changes
- Adds extra directory in src folder called '/templates/'
- 
### Screenshots or Video GIFs
![image](https://user-images.githubusercontent.com/45557594/125660299-97cf47a2-fe47-41e0-8feb-8683c593623e.png)


### Related Issues
- Issue #64 (Templates are yet to be added and will be done by @sushilburagute 😎 )
